### PR TITLE
Update deploy branch using wild card to resolve #2

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -5,7 +5,7 @@ name: Deploy to Firebase Hosting on merge
 'on':
   push:
     branches:
-      - release
+      - release/*
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update deploy branch to `release/*` for enabling automatic deployment when merged to release branches with version number specified. 